### PR TITLE
API-2221 Check server-token for application-restricted endpoint

### DIFF
--- a/app/uk/gov/hmrc/apigateway/exception/GatewayError.scala
+++ b/app/uk/gov/hmrc/apigateway/exception/GatewayError.scala
@@ -36,11 +36,14 @@ object GatewayError {
 
   case class MissingCredentials() extends GatewayError("MISSING_CREDENTIALS", "Authentication information is not provided")
 
+  case class IncorrectAccessTokenType() extends GatewayError("INCORRECT_ACCESS_TOKEN_TYPE", "The access token type used is not supported when invoking the API")
+
   case class InvalidScope() extends GatewayError("INVALID_SCOPE", "Cannot access the required resource. Ensure this token has all the required scopes.")
 
   def recovery: PartialFunction[Throwable, Result] = {
     case e: MissingCredentials => Unauthorized(toJson(e))
     case e: InvalidCredentials => Unauthorized(toJson(e))
+    case e: IncorrectAccessTokenType => Unauthorized(toJson(e))
     case e: MatchingResourceNotFound => PlayNotFound(toJson(e))
     case e: InvalidScope => Forbidden(toJson(e))
     case e: NotFound => PlayNotFound(toJson(e))

--- a/app/uk/gov/hmrc/apigateway/play/filter/ApiGatewayFilter.scala
+++ b/app/uk/gov/hmrc/apigateway/play/filter/ApiGatewayFilter.scala
@@ -19,6 +19,7 @@ package uk.gov.hmrc.apigateway.play.filter
 import akka.stream.Materializer
 import play.api.mvc.{Filter, RequestHeader, Result}
 import uk.gov.hmrc.apigateway.exception.GatewayError
+import uk.gov.hmrc.apigateway.exception.GatewayError.MissingCredentials
 import uk.gov.hmrc.apigateway.model.ProxyRequest
 
 import scala.concurrent.ExecutionContext.Implicits.global
@@ -36,4 +37,7 @@ abstract class ApiGatewayFilter(implicit m: Materializer) extends Filter {
 
   def filter(requestHeader: RequestHeader, proxyRequest: ProxyRequest): Future[RequestHeader]
 
+  def accessToken(proxyRequest: ProxyRequest) = {
+    proxyRequest.accessToken.getOrElse(throw MissingCredentials())
+  }
 }

--- a/app/uk/gov/hmrc/apigateway/play/filter/ApplicationRestrictedEndpointFilter.scala
+++ b/app/uk/gov/hmrc/apigateway/play/filter/ApplicationRestrictedEndpointFilter.scala
@@ -55,11 +55,7 @@ class ApplicationRestrictedEndpointFilter @Inject()
   override def filter(requestHeader: RequestHeader, proxyRequest: ProxyRequest): Future[RequestHeader] =
     requestHeader.tags.get(X_API_GATEWAY_AUTH_TYPE) flatMap authType match {
       case Some(APPLICATION) =>
-        proxyRequest.accessToken match {
-          case Some(serverToken) =>
-            getApplication(serverToken, proxyRequest).map(app => requestHeader.withTag(X_APPLICATION_ID, app.id.toString))
-          case _ => throw MissingCredentials()
-        }
+            getApplication(accessToken(proxyRequest), proxyRequest).map(app => requestHeader.withTag(X_APPLICATION_ID, app.id.toString))
       case _ => successful(requestHeader)
     }
 }

--- a/app/uk/gov/hmrc/apigateway/service/ApplicationService.scala
+++ b/app/uk/gov/hmrc/apigateway/service/ApplicationService.scala
@@ -21,8 +21,8 @@ import javax.inject.{Inject, Singleton}
 import uk.gov.hmrc.apigateway.connector.impl.ThirdPartyApplicationConnector
 import uk.gov.hmrc.apigateway.exception.GatewayError.InvalidCredentials
 import uk.gov.hmrc.apigateway.model.Application
-import scala.concurrent.ExecutionContext.Implicits.global
 
+import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.Future
 
 @Singleton

--- a/test/it/uk/gov/hmrc/apigateway/BaseFeatureSpec.scala
+++ b/test/it/uk/gov/hmrc/apigateway/BaseFeatureSpec.scala
@@ -19,7 +19,7 @@ package it.uk.gov.hmrc.apigateway
 import com.github.tomakehurst.wiremock.WireMockServer
 import com.github.tomakehurst.wiremock.client.WireMock
 import com.github.tomakehurst.wiremock.core.WireMockConfiguration
-import it.uk.gov.hmrc.apigateway.stubs.{ThirdPartyDelegatedAuthorityStub, ApiStub, ApiDefinitionStub}
+import it.uk.gov.hmrc.apigateway.stubs.{ThirdPartyApplicationStub, ThirdPartyDelegatedAuthorityStub, ApiStub, ApiDefinitionStub}
 import org.scalatest._
 import org.scalatestplus.play.guice.GuiceOneServerPerSuite
 import play.api.libs.json.Json._
@@ -37,7 +37,8 @@ with GuiceOneServerPerSuite with BeforeAndAfterEach {
   val apiDefinition = ApiDefinitionStub
   val api = ApiStub
   val thirdPartyDelegatedAuthority = ThirdPartyDelegatedAuthorityStub
-  val mocks = Seq(apiDefinition, api, thirdPartyDelegatedAuthority)
+  val thirdPartyApplication = ThirdPartyApplicationStub
+  val mocks = Seq(apiDefinition, api, thirdPartyDelegatedAuthority, thirdPartyApplication)
 
   override protected def beforeAll(): Unit = {
     mocks.foreach(m => if (!m.stub.server.isRunning) m.stub.server.start())

--- a/test/it/uk/gov/hmrc/apigateway/stubs/ApiDefinitionStub.scala
+++ b/test/it/uk/gov/hmrc/apigateway/stubs/ApiDefinitionStub.scala
@@ -21,6 +21,7 @@ import it.uk.gov.hmrc.apigateway.{MockHost, Stub}
 import play.api.libs.json.Json.{toJson, stringify}
 import uk.gov.hmrc.apigateway.model.ApiDefinition
 import uk.gov.hmrc.apigateway.play.binding.PlayBindings._
+import play.api.http.Status._
 
 object ApiDefinitionStub extends Stub {
 
@@ -28,12 +29,12 @@ object ApiDefinitionStub extends Stub {
 
   def willReturnTheApiDefinition(apiDefinition: ApiDefinition) = {
     stub.mock.register(get(urlPathEqualTo(s"/api-definition")).withQueryParam("context", equalTo(apiDefinition.context))
-      .willReturn(aResponse().withStatus(200)
+      .willReturn(aResponse().withStatus(OK)
         .withBody(stringify(toJson(apiDefinition)))))
   }
 
   def willNotReturnAnApiDefinitionForContext(context: String) = {
     stub.mock.register(get(urlPathEqualTo(s"/api-definition")).withQueryParam("context", equalTo(context))
-      .willReturn(aResponse().withStatus(404)))
+      .willReturn(aResponse().withStatus(NOT_FOUND)))
   }
 }

--- a/test/it/uk/gov/hmrc/apigateway/stubs/ApiStub.scala
+++ b/test/it/uk/gov/hmrc/apigateway/stubs/ApiStub.scala
@@ -18,6 +18,7 @@ package it.uk.gov.hmrc.apigateway.stubs
 
 import com.github.tomakehurst.wiremock.client.WireMock._
 import it.uk.gov.hmrc.apigateway.{MockHost, Stub}
+import play.api.http.Status.OK
 
 object ApiStub extends Stub {
 
@@ -28,6 +29,6 @@ object ApiStub extends Stub {
 
   def willReturnTheResponse(response: String) = {
     stub.mock.register(get(anyUrl())
-      .willReturn(aResponse().withStatus(200).withBody(response)))
+      .willReturn(aResponse().withStatus(OK).withBody(response)))
   }
 }

--- a/test/it/uk/gov/hmrc/apigateway/stubs/ThirdPartyApplicationStub.scala
+++ b/test/it/uk/gov/hmrc/apigateway/stubs/ThirdPartyApplicationStub.scala
@@ -18,22 +18,22 @@ package it.uk.gov.hmrc.apigateway.stubs
 
 import com.github.tomakehurst.wiremock.client.WireMock._
 import it.uk.gov.hmrc.apigateway.{MockHost, Stub}
-import play.api.libs.json.Json.{stringify, toJson}
-import uk.gov.hmrc.apigateway.model.Authority
+import play.api.libs.json.Json._
+import uk.gov.hmrc.apigateway.model.Application
 import uk.gov.hmrc.apigateway.play.binding.PlayBindings._
 import play.api.http.Status._
 
-object ThirdPartyDelegatedAuthorityStub extends Stub {
-  override val stub = new MockHost(22222)
+object ThirdPartyApplicationStub extends Stub {
+  override val stub = new MockHost(22223)
 
-  def willReturnTheAuthorityForAccessToken(accessToken: String, authority: Authority) = {
-    stub.mock.register(get(urlPathEqualTo(s"/authority")).withQueryParam("access_token", equalTo(accessToken))
+  def willReturnTheApplicationForServerToken(serverToken: String, application: Application) = {
+    stub.mock.register(get(urlPathEqualTo(s"/application")).withHeader("X-server-token", equalTo(serverToken))
       .willReturn(aResponse().withStatus(OK)
-        .withBody(stringify(toJson(authority)))))
+        .withBody(stringify(toJson(application)))))
   }
 
-  def willNotReturnAnAuthorityForAccessToken(accessToken: String) = {
-    stub.mock.register(get(urlPathEqualTo(s"/authority")).withQueryParam("access_token", equalTo(accessToken))
+  def willNotReturnAnApplicationForServerToken(serverToken: String) = {
+    stub.mock.register(get(urlPathEqualTo(s"/application")).withHeader("X-server-token", equalTo(serverToken))
       .willReturn(aResponse().withStatus(NOT_FOUND)))
   }
 }


### PR DESCRIPTION
This PR adds the ability to throw a clear error when attempting to hit a _user restricted_ endpoint using a valid _server token_