### PR TITLE
API-2296 subscriptions and scopes validated in parallel

### DIFF
--- a/test/it/uk/gov/hmrc/apigateway/feature/RequestAuthorizationIntegrationSpec.scala
+++ b/test/it/uk/gov/hmrc/apigateway/feature/RequestAuthorizationIntegrationSpec.scala
@@ -134,13 +134,12 @@ class RequestAuthorizationIntegrationSpec extends BaseFeatureSpec {
     }
 
     scenario("A user restricted request, that fails with a NOT_FOUND when fetching the application by authority, is not proxied") {
-
-      Given("A valid request")
+      Given("A request to an endpoint requiring 'scope1'")
       val httpRequest = Http(s"$serviceUrl/api-simulator/userScope1")
         .header(ACCEPT, "application/vnd.hmrc.1.0+json")
         .header(AUTHORIZATION, s"Bearer $accessToken")
 
-      And("The access token matches an authority")
+      And("The access token matches an authority with 'scope1'")
       thirdPartyDelegatedAuthority.willReturnTheAuthorityForAccessToken(accessToken, authority)
 
       And("An application is not found for the delegated authority")
@@ -157,13 +156,12 @@ class RequestAuthorizationIntegrationSpec extends BaseFeatureSpec {
     }
 
     scenario("A user restricted request, that fails when fetching the application by authority, is not proxied") {
-
-      Given("A valid request")
+      Given("A request to an endpoint requiring 'scope1'")
       val httpRequest = Http(s"$serviceUrl/api-simulator/userScope1")
         .header(ACCEPT, "application/vnd.hmrc.1.0+json")
         .header(AUTHORIZATION, s"Bearer $accessToken")
 
-      And("The access token matches an authority")
+      And("The access token matches an authority with 'scope1'")
       thirdPartyDelegatedAuthority.willReturnTheAuthorityForAccessToken(accessToken, authority)
 
       And("There is an error while retrieving the application by client id")
@@ -181,12 +179,12 @@ class RequestAuthorizationIntegrationSpec extends BaseFeatureSpec {
 
     scenario("A user restricted request that fails when fetching the application subscriptions is not proxied") {
 
-      Given("A valid request")
+      Given("A request to an endpoint requiring 'scope1'")
       val httpRequest = Http(s"$serviceUrl/api-simulator/userScope1")
         .header(ACCEPT, "application/vnd.hmrc.1.0+json")
         .header(AUTHORIZATION, s"Bearer $accessToken")
 
-      And("The access token matches an authority")
+      And("The access token matches an authority with 'scope1'")
       thirdPartyDelegatedAuthority.willReturnTheAuthorityForAccessToken(accessToken, authority)
 
       And("An application exists for the delegated authority")
@@ -207,12 +205,12 @@ class RequestAuthorizationIntegrationSpec extends BaseFeatureSpec {
 
     scenario("A user restricted request with invalid subscriptions is not proxied") {
 
-      Given("A valid request")
+      Given("A request to an endpoint requiring 'scope1'")
       val httpRequest = Http(s"$serviceUrl/api-simulator/userScope1")
         .header(ACCEPT, "application/vnd.hmrc.1.0+json")
         .header(AUTHORIZATION, s"Bearer $accessToken")
 
-      And("The access token matches an authority")
+      And("The access token matches an authority with 'scope1'")
       thirdPartyDelegatedAuthority.willReturnTheAuthorityForAccessToken(accessToken, authority)
 
       And("An application exists for the delegated authority")

--- a/test/uk/gov/hmrc/apigateway/play/filter/UserRestrictedEndpointFilterSpec.scala
+++ b/test/uk/gov/hmrc/apigateway/play/filter/UserRestrictedEndpointFilterSpec.scala
@@ -86,6 +86,7 @@ class UserRestrictedEndpointFilterSpec extends UnitSpec with MockitoSugar with E
 
     "propagate the error, when there is a failure in fetching the application" in new Setup {
       mockAuthority(authorityService, validAuthority())
+      mockScopeValidation(scopeValidator)
       mockApplicationByClientId(applicationService, clientId, ServerError())
       intercept[ServerError] {
         await(underTest.filter(fakeRequest, ProxyRequest(fakeRequest)))
@@ -94,6 +95,7 @@ class UserRestrictedEndpointFilterSpec extends UnitSpec with MockitoSugar with E
 
     "decline a request not matching the application API subscriptions" in new Setup {
       mockAuthority(authorityService, validAuthority())
+      mockScopeValidation(scopeValidator)
       mockApplicationByClientId(applicationService, clientId, anApplication())
       mockApiSubscriptions(applicationService, InvalidSubscription())
       intercept[InvalidSubscription] {


### PR DESCRIPTION
This PR adds the changes required to perform parallel validation of subscriptions and scopes.
*Notes*:
* Existing tests modified so that the appropriate mocks are initialised for both validators. This ensures things fail only when the required validation fails.
* I have not found a practical way to test that those validators are executed in parallel and I'm not sure there's a lot to gain from writing such test. Bear in mind that there is no guarantee they will actually run in parallel, as that depends on many factors such as thread pool size, execution time, etc. Having said that, any suggestions and/or examples are welcome. 
